### PR TITLE
Add draggable handles for user image resizing

### DIFF
--- a/assets/css/cfp-frontend.css
+++ b/assets/css/cfp-frontend.css
@@ -22,5 +22,11 @@
 .cfp-editor-overlay{position:absolute; border:1px dashed rgba(255,255,255,.35); box-shadow:0 0 0 200vmax rgba(0,0,0,.65); pointer-events:none;}
 .cfp-editor-user{position:absolute; left:0; top:0; pointer-events:auto; cursor:grab;}
 
+.cfp-resize-handle{position:absolute;width:12px;height:12px;background:#fff;border:1px solid #000;pointer-events:auto;}
+.cfp-rh-nw{left:-6px;top:-6px;cursor:nwse-resize;}
+.cfp-rh-ne{right:-6px;top:-6px;cursor:nesw-resize;}
+.cfp-rh-sw{left:-6px;bottom:-6px;cursor:nesw-resize;}
+.cfp-rh-se{right:-6px;bottom:-6px;cursor:nwse-resize;}
+
 .cfp-modal-toolbar{display:flex; gap:8px; align-items:center; justify-content:flex-end; padding:10px; border-top:1px solid #eee;}
 .cfp-modal-toolbar .button{min-width:40px;}

--- a/includes/class-cfp-frontend.php
+++ b/includes/class-cfp-frontend.php
@@ -142,7 +142,6 @@ final class CFP_Frontend {
               <button type="button" class="button cfp-m-rot-right">⟳</button>
               <button type="button" class="button cfp-m-flip-h">⇋</button>
               <button type="button" class="button cfp-m-flip-v">⇅</button>
-              <label>Zoom <input type="range" class="cfp-m-zoom" min="0.25" max="3" step="0.01" value="1"/></label>
               <button type="button" class="button button-primary cfp-m-apply"><?php esc_html_e('Apply','wc-cfp');?></button>
               <button type="button" class="button cfp-m-cancel"><?php esc_html_e('Cancel','wc-cfp');?></button>
             </div>


### PR DESCRIPTION
## Summary
- remove zoom slider and state tracking
- add corner handles to resize the user image while preserving overlay ratio
- compute composition using resized image dimensions and style new handles

## Testing
- `node --check assets/js/cfp-frontend.js`
- `php -l includes/class-cfp-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a84c1884288333a43a8e5094270080