### PR TITLE
Bind overlay layout to window resize events

### DIFF
--- a/assets/js/cfp-frontend.js
+++ b/assets/js/cfp-frontend.js
@@ -189,10 +189,12 @@
     $('body').addClass('modal-open');
     selectFrame(state.frameIdx || 0);
     layoutOverlay();
+    $(window).off('resize.cfp').on('resize.cfp', layoutOverlay);
   }
   function closeModal(){
     $('#cfp-modal-bg, #cfp-modal').hide();
     $('body').removeClass('modal-open');
+    $(window).off('resize.cfp');
   }
 
   // Compose mockup to data URL + upload


### PR DESCRIPTION
## Summary
- Rebind the overlay layout whenever the window is resized while the modal is open
- Remove the resize listener when closing the modal to prevent leaks

## Testing
- `node --check assets/js/cfp-frontend.js`
- `node <test script>`

------
https://chatgpt.com/codex/tasks/task_e_68a8597eed388333bf8c7327dc55119e