### PR TITLE
Fix overlay scaling and dynamic aspect ratio

### DIFF
--- a/assets/css/cfp-frontend.css
+++ b/assets/css/cfp-frontend.css
@@ -17,7 +17,7 @@
 .cfp-modal-title{font-weight:600;}
 .cfp-close{background:none; border:none; font-size:22px; cursor:pointer; line-height:1;}
 .cfp-modal-body{padding:10px; overflow:auto;}
-.cfp-editor-wrap{position:relative; width:100%; aspect-ratio:1/1; background:#111; display:flex; align-items:center; justify-content:center; overflow:hidden;}
+.cfp-editor-wrap{position:relative; width:100%; background:#111; display:flex; align-items:center; justify-content:center; overflow:hidden;}
 .cfp-editor-frame{position:absolute; max-width:100%; max-height:100%; width:auto; height:auto;}
 .cfp-editor-overlay{position:absolute; border:1px dashed rgba(255,255,255,.35); box-shadow:0 0 0 200vmax rgba(0,0,0,.65); pointer-events:none;}
 .cfp-editor-user{position:absolute; left:0; top:0; pointer-events:auto; cursor:grab;}

--- a/assets/js/cfp-frontend.js
+++ b/assets/js/cfp-frontend.js
@@ -85,6 +85,7 @@
         ov.ratio = parseFloat(ov.ratio || 1) || 1;
       }
       state.overlayPx = ov;
+      $('.cfp-editor-wrap').css('aspect-ratio', FW + '/' + FH);
       $('.cfp-editor-frame').attr('src', f.url);
       layoutOverlay();
       // set label
@@ -226,9 +227,10 @@
     // Determine displayed overlay scale: user image base scale so that shorter side fits overlay
     var uw = state.userImg.naturalWidth, uh = state.userImg.naturalHeight;
     var $u = $('.cfp-editor-user');
-    var dispW = $u.width(), dispH = $u.height();
-    var scaleX = dispW/uw, scaleY = dispH/uh;
-    ctx.translate(ov.x + state.userPos.x + dispW/2, ov.y + state.userPos.y + dispH/2);
+    var ovScale = $('.cfp-editor-overlay').width() / state.overlayPx.w;
+    var dispW = $u.width() / ovScale, dispH = $u.height() / ovScale;
+    var scaleX = dispW / uw, scaleY = dispH / uh;
+    ctx.translate(ov.x + (state.userPos.x / ovScale) + dispW / 2, ov.y + (state.userPos.y / ovScale) + dispH / 2);
     var rad = (state.rot || 0) * Math.PI/180;
     ctx.rotate(rad);
     ctx.scale(state.flipH ? -1 : 1, state.flipV ? -1 : 1);
@@ -251,10 +253,11 @@
 
     var uw = state.userImg.naturalWidth, uh = state.userImg.naturalHeight;
     var $u = $('.cfp-editor-user');
-    var dispW = $u.width(), dispH = $u.height();
-    var scaleX = dispW/uw, scaleY = dispH/uh;
+    var ovScale = $('.cfp-editor-overlay').width() / state.overlayPx.w;
+    var dispW = $u.width() / ovScale, dispH = $u.height() / ovScale;
+    var scaleX = dispW / uw, scaleY = dispH / uh;
     ctx.save();
-    ctx.translate(state.userPos.x + dispW/2, state.userPos.y + dispH/2);
+    ctx.translate((state.userPos.x / ovScale) + dispW / 2, (state.userPos.y / ovScale) + dispH / 2);
     var rad = (state.rot || 0) * Math.PI/180;
     ctx.rotate(rad);
     ctx.scale(state.flipH ? -1 : 1, state.flipV ? -1 : 1);


### PR DESCRIPTION
## Summary
- compute overlay scale in compose functions and adjust user position translation
- set editor wrap aspect ratio based on selected frame

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8610f97248333bf7335fbd8edd6af