### PR TITLE
Wrap editor user image for draggable handles

### DIFF
--- a/assets/css/cfp-frontend.css
+++ b/assets/css/cfp-frontend.css
@@ -19,8 +19,9 @@
 .cfp-modal-body{padding:10px; overflow:auto;}
 .cfp-editor-wrap{position:relative; width:100%; background:#111; display:flex; align-items:center; justify-content:center; overflow:hidden;}
 .cfp-editor-frame{position:absolute; max-width:100%; max-height:100%; width:auto; height:auto;}
-.cfp-editor-overlay{position:absolute; border:1px dashed rgba(255,255,255,.35); box-shadow:0 0 0 200vmax rgba(0,0,0,.65); pointer-events:none;}
-.cfp-editor-user{position:absolute; left:0; top:0; pointer-events:auto; cursor:grab;}
+.cfp-editor-overlay{position:absolute; border:1px dashed rgba(255,255,255,.35); box-shadow:0 0 0 200vmax rgba(0,0,0,.65);}
+.cfp-editor-user{position:absolute; left:0; top:0; width:100%; height:100%; pointer-events:auto; cursor:grab;}
+.cfp-editor-user img{width:100%; height:100%; object-fit:contain;}
 
 .cfp-resize-handle{position:absolute;width:12px;height:12px;background:#fff;border:1px solid #000;pointer-events:auto;}
 .cfp-rh-nw{left:0;top:0;transform:translate(-50%,-50%);cursor:nwse-resize;}

--- a/assets/js/cfp-frontend.js
+++ b/assets/js/cfp-frontend.js
@@ -96,7 +96,7 @@
 
   function updateUserTransform(){
     var t = 'rotate(' + (state.rot || 0) + 'deg) scaleX(' + (state.flipH ? -1 : 1) + ') scaleY(' + (state.flipV ? -1 : 1) + ')';
-    $('.cfp-editor-user').css('transform', t);
+    $('.cfp-editor-user img').css('transform', t);
   }
 
   function resetUserTransform(){
@@ -291,7 +291,7 @@
     var $bg = $('#cfp-modal-bg'), $modal = $('#cfp-modal');
     var $mApply = $('.cfp-m-apply'), $mCancel = $('.cfp-m-cancel');
     var $rotL = $('.cfp-m-rot-left'), $rotR = $('.cfp-m-rot-right'), $fH = $('.cfp-m-flip-h'), $fV = $('.cfp-m-flip-v');
-    var $user = $('.cfp-editor-user');
+    var $userWrap = $('.cfp-editor-user'), $userImg = $userWrap.find('img');
 
     function loadUser(file){
       if (!file) return;
@@ -302,7 +302,7 @@
       var reader = new FileReader();
       reader.onload = function(e){
         state.userImg = new Image();
-        state.userImg.onload = function(){ openModal(); resetUserTransform(); bindDragging(); $user.attr('src', e.target.result); };
+        state.userImg.onload = function(){ openModal(); resetUserTransform(); bindDragging(); $userImg.attr('src', e.target.result); };
         state.userImg.src = e.target.result;
       };
       reader.readAsDataURL(file);

--- a/includes/class-cfp-frontend.php
+++ b/includes/class-cfp-frontend.php
@@ -133,7 +133,9 @@ final class CFP_Frontend {
               <div class="cfp-editor-wrap">
                 <img class="cfp-editor-frame" alt="frame"/>
                 <div class="cfp-editor-overlay">
-                  <img class="cfp-editor-user" alt=""/>
+                  <div class="cfp-editor-user">
+                    <img class="cfp-user-img" alt="" />
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace user image markup with wrapper div to host resize handles
- Enable pointer events and sizing for new wrapper, add inner image styling
- Update frontend script to target wrapper and inner image for transforms and loading

## Testing
- `php -l includes/class-cfp-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a86710a8cc8333a4c6af5444a9d594