### PR TITLE
Remove rotation and flip options from frame preview editor

### DIFF
--- a/includes/class-cfp-frontend.php
+++ b/includes/class-cfp-frontend.php
@@ -140,10 +140,6 @@ final class CFP_Frontend {
               </div>
             </div>
             <div class="cfp-modal-toolbar">
-              <button type="button" class="button cfp-m-rot-left">⟲</button>
-              <button type="button" class="button cfp-m-rot-right">⟳</button>
-              <button type="button" class="button cfp-m-flip-h">⇋</button>
-              <button type="button" class="button cfp-m-flip-v">⇅</button>
               <button type="button" class="button button-primary cfp-m-apply"><?php esc_html_e('Apply','wc-cfp');?></button>
               <button type="button" class="button cfp-m-cancel"><?php esc_html_e('Cancel','wc-cfp');?></button>
             </div>


### PR DESCRIPTION
## Summary
- remove rotation and flip buttons from modal toolbar
- simplify frontend script: drop rotation/flip state and handlers, reset transform logic
- draw user image using size and translation only

## Testing
- `php -l includes/class-cfp-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8681938788333a549a07645a6dd57